### PR TITLE
Add match for :warning: as breaking change indicator

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -325,7 +325,7 @@ parse_raw_commit = function(raw) {
   lines = lines.filter(function(line) {
     return find_fixes(line, msg);
   });
-  match = raw.match(/BREAKING CHANGE:([\s\S]*)/);
+  match = raw.match(/(?:BREAKING CHANGE|:warning):([\s\S]*)/);
   if (match) {
     msg.breaking = match[1];
   }

--- a/src/git_utils.coffee
+++ b/src/git_utils.coffee
@@ -120,7 +120,7 @@ parse_raw_commit = (raw) ->
   lines = lines.filter (line) ->
     find_fixes(line, msg)
 
-  match = raw.match(/BREAKING CHANGE:([\s\S]*)/)
+  match = raw.match(/(?:BREAKING CHANGE|:warning):([\s\S]*)/)
   msg.breaking = match[1] if match
   msg.body = lines.join("\n")
 


### PR DESCRIPTION
Small change to save some typing on breaking changes, allows using either
`:warning:` or `BREAKING CHANGE:` in commit logs.

It would actually be nice to refactor breaking changes out into another section,
with a `match_body` attribute or something, then this feature could be used to
match any expression in the body, but that's a job for another day.
