### PR TITLE
Fix log output corrupting markdown

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -61,11 +61,11 @@ first_to_exists = function() {
 };
 
 warn = function() {
-  return console.log("WARNING:", util.format.apply(null, arguments));
+  return console.error("WARNING:", util.format.apply(null, arguments));
 };
 
 error = function() {
-  console.log("ERROR:", util.format.apply(null, arguments));
+  console.error("ERROR:", util.format.apply(null, arguments));
   return process.exit();
 };
 
@@ -600,7 +600,7 @@ q.all([first_commit, all_tags, get_start, get_end, all_tags_date]).then(function
     return q.all(read_commits).then(curate_versions(tags_steps)).then(function(versions) {
       return print_versions(versions, tags_date);
     }).fail(function(reason) {
-      return console.log(reason);
+      return console.error(reason);
     });
   });
 });

--- a/src/boot.coffee
+++ b/src/boot.coffee
@@ -30,10 +30,10 @@ first_to_exists = (files...) ->
   return file for file in files when fs.existsSync(file)
 
 warn = ->
-  console.log "WARNING:", util.format.apply(null, arguments)
+  console.error "WARNING:", util.format.apply(null, arguments)
 
 error = ->
-  console.log "ERROR:", util.format.apply(null, arguments)
+  console.error "ERROR:", util.format.apply(null, arguments)
   process.exit()
 
 string_or_url = (field) ->

--- a/src/changelog.coffee
+++ b/src/changelog.coffee
@@ -55,4 +55,4 @@ q.all([first_commit, all_tags, get_start, get_end, all_tags_date]).then ([first_
     .then (versions) ->
       print_versions(versions, tags_date)
     .fail (reason) ->
-      console.log reason
+      console.error reason


### PR DESCRIPTION
Use `console.error` rather than `console.log` so logs go to stderr
